### PR TITLE
Add default binding to adorned element Visibility for Adorner

### DIFF
--- a/src/Orc.Theming/Adorners/AsterixAdorner.cs
+++ b/src/Orc.Theming/Adorners/AsterixAdorner.cs
@@ -2,6 +2,7 @@
 {
     using System.Globalization;
     using System.Windows;
+    using System.Windows.Data;
     using System.Windows.Documents;
     using System.Windows.Media;
 
@@ -17,6 +18,11 @@
         {
             _padding = padding;
             _positionCorner = positionCorner;
+
+            // Bind to element's Visibility
+            Binding binding = new Binding("Visibility");
+            binding.Source = adornedElement;
+            SetBinding(VisibilityProperty, binding);
         }
 
         protected override void OnRender(DrawingContext drawingContext)


### PR DESCRIPTION
### Description of Change ###

Fix mandatorty field asterix visibility if adorned element isn't visible

### Issues Resolved ### 

- fixes 

### API Changes ###
 
None

### Platforms Affected ### 

- WPF


### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
