### PR TITLE
Improve sizing of default WPF controls

### DIFF
--- a/src/Orc.Theming.Tests/PublicApiFacts.Orc_Theming_HasNoBreakingChanges_Async.verified.txt
+++ b/src/Orc.Theming.Tests/PublicApiFacts.Orc_Theming_HasNoBreakingChanges_Async.verified.txt
@@ -152,6 +152,8 @@ namespace Orc.Theming
         public double? Delta { get; set; }
         [System.Windows.Markup.ConstructorArgument("mode")]
         public Orc.Theming.FontSizeMode Mode { get; set; }
+        [System.Windows.Markup.ConstructorArgument("resourceKey")]
+        public string? ResourceKey { get; set; }
         [System.Windows.Markup.ConstructorArgument("scale")]
         public double? Scale { get; set; }
         [System.Windows.Markup.ConstructorArgument("subscribeToEvents")]

--- a/src/Orc.Theming/Markup/FontSize.cs
+++ b/src/Orc.Theming/Markup/FontSize.cs
@@ -73,10 +73,10 @@ public class FontSize : UpdatableMarkupExtension
     public FontSizeMode Mode { get; set; }
 
     /// <summary>
-    /// Gets or sets the name of the resource to use when calculating the value.
+    /// Gets or sets the key of the resource to use when calculating the value.
     /// </summary>
-    [ConstructorArgument("resourceName")]
-    public string? ResourceName { get; set; }
+    [ConstructorArgument("resourceKey")]
+    public string? ResourceKey { get; set; }
 
     /// <summary>
     /// Gets or sets whether this markup extension should subscribe to events to be responsive.
@@ -125,8 +125,8 @@ public class FontSize : UpdatableMarkupExtension
         var mode = Mode;
 
         // Enforce resource mode when a resource name is available
-        var resourceName = ResourceName;
-        if (!string.IsNullOrWhiteSpace(resourceName))
+        var resourceKey = ResourceKey;
+        if (!string.IsNullOrWhiteSpace(resourceKey))
         {
             mode = FontSizeMode.Resource;
         }
@@ -209,15 +209,15 @@ public class FontSize : UpdatableMarkupExtension
 
     protected virtual double GetFontSizeFromResource()
     {
-        var resourceName = ResourceName;
-        if (!string.IsNullOrWhiteSpace(resourceName))
+        var resourceKey = ResourceKey;
+        if (!string.IsNullOrWhiteSpace(resourceKey))
         {
             if (TargetObject is DependencyObject dependencyObject)
             {
                 var frameworkElement = dependencyObject.FindLogicalOrVisualAncestorByType<FrameworkElement>();
                 if (frameworkElement is not null)
                 {
-                    var resource = frameworkElement.TryFindResource(resourceName);
+                    var resource = frameworkElement.TryFindResource(resourceKey);
                     if (resource is double doubleValue)
                     {
                         return doubleValue;
@@ -229,7 +229,7 @@ public class FontSize : UpdatableMarkupExtension
             var application = Application.Current;
             if (application is not null)
             {
-                var resource = application.TryFindResource(resourceName);
+                var resource = application.TryFindResource(resourceKey);
                 if (resource is double doubleValue)
                 {
                     return doubleValue;

--- a/src/Orc.Theming/Themes/Controls.implicit.wpf.textbox.xaml
+++ b/src/Orc.Theming/Themes/Controls.implicit.wpf.textbox.xaml
@@ -13,21 +13,20 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            Background="{TemplateBinding Background}" 
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Background="{TemplateBinding Background}"
                             SnapsToDevicePixels="True">
 
-                        <ScrollViewer x:Name="PART_ContentHost" 
-                                      Focusable="false" 
-                                      HorizontalScrollBarVisibility="Hidden" 
-                                      VerticalScrollBarVisibility="Hidden"/>
+                        <ScrollViewer x:Name="PART_ContentHost"
+                                      Focusable="false"
+                                      HorizontalScrollBarVisibility="Hidden"
+                                      VerticalScrollBarVisibility="Hidden" />
 
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-
     </Style>
 
 </ResourceDictionary>

--- a/src/Orc.Theming/Themes/Controls.implicit.wpf.textboxbase.xaml
+++ b/src/Orc.Theming/Themes/Controls.implicit.wpf.textboxbase.xaml
@@ -15,7 +15,8 @@
         <Setter Property="Control.AllowDrop" Value="true"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
         <Setter Property="Control.FocusVisualStyle" Value="{x:Null}"/>
-     
+        
+        <Setter Property="TextBoxBase.VerticalAlignment" Value="Center"/>
         <Setter Property="TextBoxBase.SelectionBrush" Value="{DynamicResource Orc.Styles.TextBox.Selection.Highlight}"/>
 
         <Style.Triggers>

--- a/src/Orc.Theming/Themes/Controls.implicit.wpf.textboxbase.xaml
+++ b/src/Orc.Theming/Themes/Controls.implicit.wpf.textboxbase.xaml
@@ -40,6 +40,10 @@
                 <Setter Property="TextBoxBase.SelectionBrush" Value="{DynamicResource Orc.Styles.TextBox.Selection.HighlightInactive}"/>
             </MultiTrigger>
 
+            <Trigger Property="TextBoxBase.AcceptsReturn" Value="True">
+                <Setter Property="TextBoxBase.VerticalAlignment" Value="Stretch" />
+            </Trigger>
+            
             <Trigger Property="TextBoxBase.VerticalAlignment" Value="Stretch">
                 <Setter Property="TextBoxBase.Height" Value="Auto"/>
             </Trigger>

--- a/src/Orc.Theming/Themes/Generic.generated.xaml
+++ b/src/Orc.Theming/Themes/Generic.generated.xaml
@@ -1890,6 +1890,9 @@
         </MultiTrigger.Conditions>
         <Setter Property="TextBoxBase.SelectionBrush" Value="{DynamicResource Orc.Styles.TextBox.Selection.HighlightInactive}" />
       </MultiTrigger>
+      <Trigger Property="TextBoxBase.AcceptsReturn" Value="True">
+        <Setter Property="TextBoxBase.VerticalAlignment" Value="Stretch" />
+      </Trigger>
       <Trigger Property="TextBoxBase.VerticalAlignment" Value="Stretch">
         <Setter Property="TextBoxBase.Height" Value="Auto" />
       </Trigger>

--- a/src/Orc.Theming/Themes/Generic.generated.xaml
+++ b/src/Orc.Theming/Themes/Generic.generated.xaml
@@ -1869,6 +1869,7 @@
     <Setter Property="Control.AllowDrop" Value="true" />
     <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
     <Setter Property="Control.FocusVisualStyle" Value="{x:Null}" />
+    <Setter Property="TextBoxBase.VerticalAlignment" Value="Center" />
     <Setter Property="TextBoxBase.SelectionBrush" Value="{DynamicResource Orc.Styles.TextBox.Selection.Highlight}" />
     <Style.Triggers>
       <Trigger Property="Control.IsEnabled" Value="false">
@@ -2428,7 +2429,6 @@
   <Style x:Key="{x:Type ButtonBase}" BasedOn="{StaticResource Orc.Styles.ButtonBase}" />
   <Style x:Key="DefaultCheckBoxStyle" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource Orc.Styles.CheckBox}">
     <Setter Property="Margin" Value="{DynamicResource Margin.CheckBox}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="Width" Value="Auto" />
     <Setter Property="HorizontalAlignment" Value="Left" />
     <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
@@ -2471,7 +2471,6 @@
     <Setter Property="Padding" Value="{DynamicResource Padding.TextBox}" />
     <Setter Property="Margin" Value="{DynamicResource Margin.TextBox}" />
     <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
     <Setter Property="Validation.ErrorTemplate">
@@ -2493,13 +2492,11 @@
     </Style.Triggers>
   </Style>
   <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
   </Style>
   <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource Orc.Styles.RadioButton}">
     <Setter Property="Margin" Value="{DynamicResource Margin.RadioButton}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
@@ -2523,7 +2520,6 @@
   </Style>
   <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}" BasedOn="{StaticResource Orc.Styles.RepeatButton}">
     <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="UseLayoutRounding" Value="True" />
   </Style>
   <Style x:Key="DefaultRichTextBoxStyle" TargetType="{x:Type RichTextBox}" BasedOn="{StaticResource Orc.Styles.RichTextBox}">
@@ -2534,7 +2530,6 @@
     <Setter Property="HorizontalAlignment" Value="Stretch" />
   </Style>
   <Style x:Key="DefaultSliderStyle" TargetType="{x:Type Slider}" BasedOn="{StaticResource Orc.Styles.Slider}">
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="Margin" Value="{DynamicResource Margin.Slider}" />
@@ -2548,7 +2543,6 @@
   </Style>
   <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource Orc.Styles.TextBox}">
     <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="Padding" Value="{DynamicResource Padding.TextBox}" />
     <Setter Property="Margin" Value="{DynamicResource Margin.TextBox}" />
     <!--<Setter Property="VerticalContentAlignment" Value="Center" />-->
@@ -2574,7 +2568,6 @@
   </Style>
   <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource Orc.Styles.ToggleButton}">
     <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
   </Style>
   <Style x:Key="DefaultToolTipStyle" TargetType="{x:Type ToolTip}" BasedOn="{StaticResource Orc.Styles.ToolTip}">
     <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
@@ -2709,7 +2702,6 @@
   </Style>
   <Style x:Key="DefaultButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource Orc.Styles.Button}">
     <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="UseLayoutRounding" Value="True" />
     <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
     <Setter Property="Validation.ErrorTemplate">
@@ -2732,7 +2724,6 @@
   </Style>
   <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource Orc.Styles.ComboBox}">
     <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
-    <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
     <Setter Property="MinWidth" Value="120" />

--- a/src/Orc.Theming/Themes/Generic.generated.xaml
+++ b/src/Orc.Theming/Themes/Generic.generated.xaml
@@ -2492,6 +2492,7 @@
     </Style.Triggers>
   </Style>
   <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
+    <Setter Property="MinHeight" Value="{DynamicResource Size.Height}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
   </Style>

--- a/src/Orc.Theming/Themes/Generic.generated.xaml
+++ b/src/Orc.Theming/Themes/Generic.generated.xaml
@@ -2495,7 +2495,7 @@
     </Style.Triggers>
   </Style>
   <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
-    <Setter Property="MinHeight" Value="{DynamicResource Size.Height}" />
+    <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
     <Setter Property="VerticalAlignment" Value="Center" />
     <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
   </Style>

--- a/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
+++ b/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
@@ -48,9 +48,7 @@
 
     <!-- Buttons -->
     <Style x:Key="DefaultButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource Orc.Styles.Button}">
-
         <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="UseLayoutRounding" Value="True" />
 
         <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
@@ -81,9 +79,7 @@
 
     <!-- CheckBox -->
     <Style x:Key="DefaultCheckBoxStyle" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource Orc.Styles.CheckBox}">
-
         <Setter Property="Margin" Value="{DynamicResource Margin.CheckBox}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="Width" Value="Auto" />
         <Setter Property="HorizontalAlignment" Value="Left" />
 
@@ -111,9 +107,7 @@
 
     <!-- ComboBox -->
     <Style x:Key="DefaultComboBoxStyle" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource Orc.Styles.ComboBox}">
-        
         <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="MinWidth" Value="120" />
@@ -143,9 +137,7 @@
 
     <!-- ComboBox -->
     <Style x:Key="DefaultDataGridStyle" TargetType="{x:Type DataGrid}" BasedOn="{StaticResource {x:Type DataGrid}}">
-
         <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
-
     </Style>
 
     <!-- GroupBox -->
@@ -190,7 +182,6 @@
         <Setter Property="Padding" Value="{DynamicResource Padding.TextBox}" />
         <Setter Property="Margin" Value="{DynamicResource Margin.TextBox}" />
         <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center" />
 
         <!-- Due to a bug, adjust the error template (see http://stackoverflow.com/questions/321327/how-do-i-get-rid-of-the-red-rectangle-when-my-wpf-binding-validation-has-failed-a) -->
@@ -217,7 +208,6 @@
 
     <!-- Progress bar -->
     <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
     </Style>
@@ -225,7 +215,6 @@
     <!-- RadioButton -->
     <Style x:Key="DefaultRadioButtonStyle" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource Orc.Styles.RadioButton}">
         <Setter Property="Margin" Value="{DynamicResource Margin.RadioButton}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
 
@@ -254,7 +243,6 @@
     <!-- RepeatButton -->
     <Style x:Key="DefaultRepeatButtonStyle" TargetType="{x:Type RepeatButton}" BasedOn="{StaticResource Orc.Styles.RepeatButton}">
         <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="UseLayoutRounding" Value="True" />
     </Style>
 
@@ -269,7 +257,6 @@
 
     <!-- Slider -->
     <Style x:Key="DefaultSliderStyle" TargetType="{x:Type Slider}" BasedOn="{StaticResource Orc.Styles.Slider}">
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Margin" Value="{DynamicResource Margin.Slider}" />
@@ -294,7 +281,6 @@
     <Style x:Key="DefaultTextBoxStyle" TargetType="{x:Type TextBox}" BasedOn="{StaticResource Orc.Styles.TextBox}">
 
         <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
         <Setter Property="Padding" Value="{DynamicResource Padding.TextBox}" />
         <Setter Property="Margin" Value="{DynamicResource Margin.TextBox}" />
         <!--<Setter Property="VerticalContentAlignment" Value="Center" />-->
@@ -325,7 +311,6 @@
     <!-- ToggleButton -->
     <Style x:Key="DefaultToggleButtonStyle" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource Orc.Styles.ToggleButton}">
         <Setter Property="Margin" Value="{DynamicResource Margin.Button}" />
-        <Setter Property="Height" Value="{DynamicResource Size.Height}" />
     </Style>
     
     <!-- ToolBar -->

--- a/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
+++ b/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
@@ -208,6 +208,7 @@
 
     <!-- Progress bar -->
     <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
+        <Setter Property="MinHeight" Value="{DynamicResource Size.Height}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
     </Style>

--- a/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
+++ b/src/Orc.Theming/Themes/Theming.defaultstyles.wpf.xaml
@@ -208,7 +208,7 @@
 
     <!-- Progress bar -->
     <Style x:Key="DefaultProgressBarStyle" TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource Orc.Styles.ProgressBar}">
-        <Setter Property="MinHeight" Value="{DynamicResource Size.Height}" />
+        <Setter Property="MinHeight" Value="{DynamicResource Size.MinHeight}" />
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Margin" Value="{DynamicResource Margin.Default}" />
     </Style>

--- a/src/Orc.Theming/Themes/Theming.sizes.large.xaml
+++ b/src/Orc.Theming/Themes/Theming.sizes.large.xaml
@@ -1,45 +1,47 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                    xmlns:local="clr-namespace:Orc.Theming">
 
-	<!-- Sizes -->
-	<sys:Double x:Key="Size.MinHeight">28</sys:Double>
+    <!-- Sizes -->
+    <sys:Double x:Key="Size.MinHeight">27</sys:Double>
+    <sys:Double x:Key="Size.Height">27</sys:Double>
 
-	<sys:Double x:Key="Size.Image.VerySmall">24</sys:Double>
-	<sys:Double x:Key="Size.Image.Small">34</sys:Double>
-	<sys:Double x:Key="Size.Image.Medium">46</sys:Double>
-	<sys:Double x:Key="Size.Image.Large">86</sys:Double>
-	<sys:Double x:Key="Size.Image.VeryLarge">116</sys:Double>
+    <sys:Double x:Key="Size.Image.VerySmall">24</sys:Double>
+    <sys:Double x:Key="Size.Image.Small">34</sys:Double>
+    <sys:Double x:Key="Size.Image.Medium">46</sys:Double>
+    <sys:Double x:Key="Size.Image.Large">86</sys:Double>
+    <sys:Double x:Key="Size.Image.VeryLarge">116</sys:Double>
 
-	<!-- Margin sizes -->
-	<sys:Double x:Key="MarginSize.Default">8</sys:Double>
+    <!-- Margin sizes -->
+    <sys:Double x:Key="MarginSize.Default">8</sys:Double>
 
-	<sys:Double x:Key="MarginSize.Button.X">8</sys:Double>
-	<sys:Double x:Key="MarginSize.Button.Y">8</sys:Double>
-	<sys:Double x:Key="MarginSize.CheckBox.X">10</sys:Double>
-	<sys:Double x:Key="MarginSize.CheckBox.Y">6</sys:Double>
-	<sys:Double x:Key="MarginSize.GroupBox.X">6</sys:Double>
-	<sys:Double x:Key="MarginSize.GroupBox.Y">0</sys:Double>
-	<sys:Double x:Key="MarginSize.Label.X">6</sys:Double>
-	<sys:Double x:Key="MarginSize.Label.Y">8</sys:Double>
-	<sys:Double x:Key="MarginSize.RadioButton.X">10</sys:Double>
-	<sys:Double x:Key="MarginSize.RadioButton.Y">4</sys:Double>
+    <sys:Double x:Key="MarginSize.Button.X">8</sys:Double>
+    <sys:Double x:Key="MarginSize.Button.Y">8</sys:Double>
+    <sys:Double x:Key="MarginSize.CheckBox.X">10</sys:Double>
+    <sys:Double x:Key="MarginSize.CheckBox.Y">6</sys:Double>
+    <sys:Double x:Key="MarginSize.GroupBox.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.GroupBox.Y">0</sys:Double>
+    <sys:Double x:Key="MarginSize.Label.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.Label.Y">8</sys:Double>
+    <sys:Double x:Key="MarginSize.RadioButton.X">10</sys:Double>
+    <sys:Double x:Key="MarginSize.RadioButton.Y">4</sys:Double>
     <sys:Double x:Key="MarginSize.Slider.X">8</sys:Double>
     <sys:Double x:Key="MarginSize.Slider.Y">6</sys:Double>
     <sys:Double x:Key="MarginSize.TextBlock.X">4</sys:Double>
-	<sys:Double x:Key="MarginSize.TextBlock.Y">4</sys:Double>
+    <sys:Double x:Key="MarginSize.TextBlock.Y">4</sys:Double>
     <sys:Double x:Key="MarginSize.TextBox.X">8</sys:Double>
     <sys:Double x:Key="MarginSize.TextBox.Y">8</sys:Double>
 
     <!-- Padding sizes -->
-	<sys:Double x:Key="PaddingSize.Default">NaN</sys:Double>
+    <sys:Double x:Key="PaddingSize.Default">NaN</sys:Double>
 
-	<sys:Double x:Key="PaddingSize.Label.X">-1</sys:Double>
-	<sys:Double x:Key="PaddingSize.Label.Y">4</sys:Double>
-	<sys:Double x:Key="PaddingSize.TextBox.X">8</sys:Double>
-	<sys:Double x:Key="PaddingSize.TextBox.Y">8</sys:Double>
+    <sys:Double x:Key="PaddingSize.Label.X">-1</sys:Double>
+    <sys:Double x:Key="PaddingSize.Label.Y">4</sys:Double>
+    <sys:Double x:Key="PaddingSize.TextBox.X">8</sys:Double>
+    <sys:Double x:Key="PaddingSize.TextBox.Y">8</sys:Double>
 
-	<!-- 
+    <!-- 
 	
 		ALL STYLES BELOW ARE DETERMINED DYNAMICALLY
 	
@@ -52,24 +54,80 @@
 	
 	-->
 
-	<!-- Margins -->
-	<Thickness x:Key="Margin.Default" Left="{StaticResource MarginSize.Default}" Top="{StaticResource MarginSize.Default}" Right="{StaticResource MarginSize.Default}" Bottom="{StaticResource MarginSize.Default}" />
+    <!-- Margins -->
+    <Thickness x:Key="Margin.Default"
+               Left="{StaticResource MarginSize.Default}"
+               Top="{StaticResource MarginSize.Default}"
+               Right="{StaticResource MarginSize.Default}"
+               Bottom="{StaticResource MarginSize.Default}" />
 
-	<Thickness x:Key="Margin.Button" Left="{StaticResource MarginSize.Button.X}" Top="{StaticResource MarginSize.Button.Y}" Right="{StaticResource MarginSize.Button.X}" Bottom="{StaticResource MarginSize.Button.Y}" />
-	<Thickness x:Key="Margin.Button.LeftAligned" Left="0" Top="{StaticResource MarginSize.Button.Y}" Right="{StaticResource MarginSize.Button.X}" Bottom="0" />
-	<Thickness x:Key="Margin.Button.RightAligned" Left="{StaticResource MarginSize.Button.X}" Top="{StaticResource MarginSize.Button.Y}" Right="0" Bottom="0" />
-	<Thickness x:Key="Margin.CheckBox" Left="{StaticResource MarginSize.CheckBox.X}" Top="{StaticResource MarginSize.CheckBox.Y}" Right="{StaticResource MarginSize.CheckBox.X}" Bottom="{StaticResource MarginSize.CheckBox.Y}" />
-	<Thickness x:Key="Margin.GroupBox" Left="{StaticResource MarginSize.GroupBox.X}" Top="{StaticResource MarginSize.GroupBox.Y}" Right="{StaticResource MarginSize.GroupBox.X}" Bottom="{StaticResource MarginSize.GroupBox.Y}" />
-	<Thickness x:Key="Margin.Label" Left="{StaticResource MarginSize.Label.X}" Top="{StaticResource MarginSize.Label.Y}" Right="{StaticResource MarginSize.Label.X}" Bottom="{StaticResource MarginSize.Label.Y}" />
-	<Thickness x:Key="Margin.RadioButton" Left="{StaticResource MarginSize.RadioButton.X}" Top="{StaticResource MarginSize.RadioButton.Y}" Right="{StaticResource MarginSize.RadioButton.X}" Bottom="{StaticResource MarginSize.RadioButton.Y}" />
-    <Thickness x:Key="Margin.Slider" Left="{StaticResource MarginSize.Slider.X}" Top="{StaticResource MarginSize.Slider.Y}" Right="{StaticResource MarginSize.Slider.X}" Bottom="{StaticResource MarginSize.Slider.Y}" />
-	<Thickness x:Key="Margin.TextBlock" Left="{StaticResource MarginSize.TextBlock.X}" Top="{StaticResource MarginSize.TextBlock.Y}" Right="{StaticResource MarginSize.TextBlock.X}" Bottom="{StaticResource MarginSize.TextBlock.Y}" />
-    <Thickness x:Key="Margin.TextBox" Left="{StaticResource MarginSize.TextBox.X}" Top="{StaticResource MarginSize.TextBox.Y}" Right="{StaticResource MarginSize.TextBox.X}" Bottom="{StaticResource MarginSize.TextBox.Y}" />
+    <Thickness x:Key="Margin.Button"
+               Left="{StaticResource MarginSize.Button.X}"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="{StaticResource MarginSize.Button.X}"
+               Bottom="{StaticResource MarginSize.Button.Y}" />
+    <Thickness x:Key="Margin.Button.LeftAligned"
+               Left="0"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="{StaticResource MarginSize.Button.X}"
+               Bottom="0" />
+    <Thickness x:Key="Margin.Button.RightAligned"
+               Left="{StaticResource MarginSize.Button.X}"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="0"
+               Bottom="0" />
+    <Thickness x:Key="Margin.CheckBox"
+               Left="{StaticResource MarginSize.CheckBox.X}"
+               Top="{StaticResource MarginSize.CheckBox.Y}"
+               Right="{StaticResource MarginSize.CheckBox.X}"
+               Bottom="{StaticResource MarginSize.CheckBox.Y}" />
+    <Thickness x:Key="Margin.GroupBox"
+               Left="{StaticResource MarginSize.GroupBox.X}"
+               Top="{StaticResource MarginSize.GroupBox.Y}"
+               Right="{StaticResource MarginSize.GroupBox.X}"
+               Bottom="{StaticResource MarginSize.GroupBox.Y}" />
+    <Thickness x:Key="Margin.Label"
+               Left="{StaticResource MarginSize.Label.X}"
+               Top="{StaticResource MarginSize.Label.Y}"
+               Right="{StaticResource MarginSize.Label.X}"
+               Bottom="{StaticResource MarginSize.Label.Y}" />
+    <Thickness x:Key="Margin.RadioButton"
+               Left="{StaticResource MarginSize.RadioButton.X}"
+               Top="{StaticResource MarginSize.RadioButton.Y}"
+               Right="{StaticResource MarginSize.RadioButton.X}"
+               Bottom="{StaticResource MarginSize.RadioButton.Y}" />
+    <Thickness x:Key="Margin.Slider"
+               Left="{StaticResource MarginSize.Slider.X}"
+               Top="{StaticResource MarginSize.Slider.Y}"
+               Right="{StaticResource MarginSize.Slider.X}"
+               Bottom="{StaticResource MarginSize.Slider.Y}" />
+    <Thickness x:Key="Margin.TextBlock"
+               Left="{StaticResource MarginSize.TextBlock.X}"
+               Top="{StaticResource MarginSize.TextBlock.Y}"
+               Right="{StaticResource MarginSize.TextBlock.X}"
+               Bottom="{StaticResource MarginSize.TextBlock.Y}" />
+    <Thickness x:Key="Margin.TextBox"
+               Left="{StaticResource MarginSize.TextBox.X}"
+               Top="{StaticResource MarginSize.TextBox.Y}"
+               Right="{StaticResource MarginSize.TextBox.X}"
+               Bottom="{StaticResource MarginSize.TextBox.Y}" />
 
-	<!-- Paddings -->
-	<Thickness x:Key="Padding.Default" Left="{StaticResource PaddingSize.Default}" Top="{StaticResource PaddingSize.Default}" Right="{StaticResource PaddingSize.Default}" Bottom="{StaticResource PaddingSize.Default}" />
+    <!-- Paddings -->
+    <Thickness x:Key="Padding.Default"
+               Left="{StaticResource PaddingSize.Default}"
+               Top="{StaticResource PaddingSize.Default}"
+               Right="{StaticResource PaddingSize.Default}"
+               Bottom="{StaticResource PaddingSize.Default}" />
 
-	<Thickness x:Key="Padding.Label" Left="{StaticResource PaddingSize.Label.X}" Top="{StaticResource PaddingSize.Label.Y}" Right="{StaticResource PaddingSize.Label.X}" Bottom="{StaticResource PaddingSize.Label.Y}" />
-	<Thickness x:Key="Padding.TextBox" Left="{StaticResource PaddingSize.TextBox.X}" Top="{StaticResource PaddingSize.TextBox.Y}" Right="{StaticResource PaddingSize.TextBox.X}" Bottom="{StaticResource PaddingSize.TextBox.Y}" />
+    <Thickness x:Key="Padding.Label"
+               Left="{StaticResource PaddingSize.Label.X}"
+               Top="{StaticResource PaddingSize.Label.Y}"
+               Right="{StaticResource PaddingSize.Label.X}"
+               Bottom="{StaticResource PaddingSize.Label.Y}" />
+    <Thickness x:Key="Padding.TextBox"
+               Left="{StaticResource PaddingSize.TextBox.X}"
+               Top="{StaticResource PaddingSize.TextBox.Y}"
+               Right="{StaticResource PaddingSize.TextBox.X}"
+               Bottom="{StaticResource PaddingSize.TextBox.Y}" />
 
 </ResourceDictionary>

--- a/src/Orc.Theming/Themes/Theming.sizes.normal.xaml
+++ b/src/Orc.Theming/Themes/Theming.sizes.normal.xaml
@@ -1,48 +1,49 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                    xmlns:local="clr-namespace:Orc.Theming">
 
-	<!-- Sizes -->
-	<sys:Double x:Key="Size.MinHeight">27</sys:Double>
+    <!-- Sizes -->
+    <sys:Double x:Key="Size.MinHeight">27</sys:Double>
     <sys:Double x:Key="Size.Height">27</sys:Double>
 
-	<sys:Double x:Key="Size.Image.VerySmall">16</sys:Double>
-	<sys:Double x:Key="Size.Image.Small">23</sys:Double>
-	<sys:Double x:Key="Size.Image.Medium">33</sys:Double>
-	<sys:Double x:Key="Size.Image.Large">72</sys:Double>
-	<sys:Double x:Key="Size.Image.VeryLarge">96</sys:Double>
+    <sys:Double x:Key="Size.Image.VerySmall">16</sys:Double>
+    <sys:Double x:Key="Size.Image.Small">23</sys:Double>
+    <sys:Double x:Key="Size.Image.Medium">33</sys:Double>
+    <sys:Double x:Key="Size.Image.Large">72</sys:Double>
+    <sys:Double x:Key="Size.Image.VeryLarge">96</sys:Double>
 
-	<!-- Margin sizes -->
-	<sys:Double x:Key="MarginSize.Default">6</sys:Double>
+    <!-- Margin sizes -->
+    <sys:Double x:Key="MarginSize.Default">6</sys:Double>
 
-	<sys:Double x:Key="MarginSize.Button.X">6</sys:Double>
-	<sys:Double x:Key="MarginSize.Button.Y">6</sys:Double>
-	<sys:Double x:Key="MarginSize.CheckBox.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.Button.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.Button.Y">6</sys:Double>
+    <sys:Double x:Key="MarginSize.CheckBox.X">6</sys:Double>
     <sys:Double x:Key="MarginSize.CheckBox.Y">8</sys:Double>
-	<sys:Double x:Key="MarginSize.GroupBox.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.GroupBox.X">6</sys:Double>
     <sys:Double x:Key="MarginSize.GroupBox.Y">4</sys:Double>
-	<sys:Double x:Key="MarginSize.Label.X">3</sys:Double>
-	<sys:Double x:Key="MarginSize.Label.Y">8</sys:Double>
-	<sys:Double x:Key="MarginSize.RadioButton.X">6</sys:Double>
-	<sys:Double x:Key="MarginSize.RadioButton.Y">8</sys:Double>
+    <sys:Double x:Key="MarginSize.Label.X">3</sys:Double>
+    <sys:Double x:Key="MarginSize.Label.Y">8</sys:Double>
+    <sys:Double x:Key="MarginSize.RadioButton.X">6</sys:Double>
+    <sys:Double x:Key="MarginSize.RadioButton.Y">8</sys:Double>
     <sys:Double x:Key="MarginSize.Slider.X">6</sys:Double>
     <sys:Double x:Key="MarginSize.Slider.Y">6</sys:Double>
-	<sys:Double x:Key="MarginSize.TextBlock.X">2</sys:Double>
-	<sys:Double x:Key="MarginSize.TextBlock.Y">2</sys:Double>
+    <sys:Double x:Key="MarginSize.TextBlock.X">2</sys:Double>
+    <sys:Double x:Key="MarginSize.TextBlock.Y">2</sys:Double>
     <sys:Double x:Key="MarginSize.TextBox.X">6</sys:Double>
     <sys:Double x:Key="MarginSize.TextBox.Y">6</sys:Double>
 
-	<!-- Padding sizes -->
-	<sys:Double x:Key="PaddingSize.Default">NaN</sys:Double>
+    <!-- Padding sizes -->
+    <sys:Double x:Key="PaddingSize.Default">NaN</sys:Double>
 
-	<sys:Double x:Key="PaddingSize.Label.X">0</sys:Double>
-	<sys:Double x:Key="PaddingSize.Label.Y">2</sys:Double>
+    <sys:Double x:Key="PaddingSize.Label.X">0</sys:Double>
+    <sys:Double x:Key="PaddingSize.Label.Y">2</sys:Double>
     <sys:Double x:Key="PaddingSize.TextBox.X">2</sys:Double>
     <sys:Double x:Key="PaddingSize.TextBox.Y">4</sys:Double>
     <sys:Double x:Key="PaddingSize.Combobox.X">2</sys:Double>
     <sys:Double x:Key="PaddingSize.Combobox.Y">3</sys:Double>
-	
-	<!-- 
+
+    <!-- 
 	
 		ALL STYLES BELOW ARE DETERMINED DYNAMICALLY
 	
@@ -56,24 +57,84 @@
 	-->
 
     <!-- Margins -->
-    <Thickness x:Key="Margin.Default" Left="{StaticResource MarginSize.Default}" Top="{StaticResource MarginSize.Default}" Right="{StaticResource MarginSize.Default}" Bottom="{StaticResource MarginSize.Default}" />
+    <Thickness x:Key="Margin.Default"
+               Left="{StaticResource MarginSize.Default}"
+               Top="{StaticResource MarginSize.Default}"
+               Right="{StaticResource MarginSize.Default}"
+               Bottom="{StaticResource MarginSize.Default}" />
 
-    <Thickness x:Key="Margin.Button" Left="{StaticResource MarginSize.Button.X}" Top="{StaticResource MarginSize.Button.Y}" Right="{StaticResource MarginSize.Button.X}" Bottom="{StaticResource MarginSize.Button.Y}" />
-    <Thickness x:Key="Margin.Button.LeftAligned" Left="0" Top="{StaticResource MarginSize.Button.Y}" Right="{StaticResource MarginSize.Button.X}" Bottom="0" />
-    <Thickness x:Key="Margin.Button.RightAligned" Left="{StaticResource MarginSize.Button.X}" Top="{StaticResource MarginSize.Button.Y}" Right="0" Bottom="0" />
-    <Thickness x:Key="Margin.CheckBox" Left="{StaticResource MarginSize.CheckBox.X}" Top="{StaticResource MarginSize.CheckBox.Y}" Right="{StaticResource MarginSize.CheckBox.X}" Bottom="{StaticResource MarginSize.CheckBox.Y}" />
-    <Thickness x:Key="Margin.GroupBox" Left="{StaticResource MarginSize.GroupBox.X}" Top="{StaticResource MarginSize.GroupBox.Y}" Right="{StaticResource MarginSize.GroupBox.X}" Bottom="{StaticResource MarginSize.GroupBox.Y}" />
-    <Thickness x:Key="Margin.Label" Left="{StaticResource MarginSize.Label.X}" Top="{StaticResource MarginSize.Label.Y}" Right="{StaticResource MarginSize.Label.X}" Bottom="{StaticResource MarginSize.Label.Y}" />
-    <Thickness x:Key="Margin.RadioButton" Left="{StaticResource MarginSize.RadioButton.X}" Top="{StaticResource MarginSize.RadioButton.Y}" Right="{StaticResource MarginSize.RadioButton.X}" Bottom="{StaticResource MarginSize.RadioButton.Y}" />
-    <Thickness x:Key="Margin.Slider" Left="{StaticResource MarginSize.Slider.X}" Top="{StaticResource MarginSize.Slider.Y}" Right="{StaticResource MarginSize.Slider.X}" Bottom="{StaticResource MarginSize.Slider.Y}" />
-    <Thickness x:Key="Margin.TextBlock" Left="{StaticResource MarginSize.TextBlock.X}" Top="{StaticResource MarginSize.TextBlock.Y}" Right="{StaticResource MarginSize.TextBlock.X}" Bottom="{StaticResource MarginSize.TextBlock.Y}" />
-    <Thickness x:Key="Margin.TextBox" Left="{StaticResource MarginSize.TextBox.X}" Top="{StaticResource MarginSize.TextBox.Y}" Right="{StaticResource MarginSize.TextBox.X}" Bottom="{StaticResource MarginSize.TextBox.Y}" />
+    <Thickness x:Key="Margin.Button"
+               Left="{StaticResource MarginSize.Button.X}"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="{StaticResource MarginSize.Button.X}"
+               Bottom="{StaticResource MarginSize.Button.Y}" />
+    <Thickness x:Key="Margin.Button.LeftAligned"
+               Left="0"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="{StaticResource MarginSize.Button.X}"
+               Bottom="0" />
+    <Thickness x:Key="Margin.Button.RightAligned"
+               Left="{StaticResource MarginSize.Button.X}"
+               Top="{StaticResource MarginSize.Button.Y}"
+               Right="0"
+               Bottom="0" />
+    <Thickness x:Key="Margin.CheckBox"
+               Left="{StaticResource MarginSize.CheckBox.X}"
+               Top="{StaticResource MarginSize.CheckBox.Y}"
+               Right="{StaticResource MarginSize.CheckBox.X}"
+               Bottom="{StaticResource MarginSize.CheckBox.Y}" />
+    <Thickness x:Key="Margin.GroupBox"
+               Left="{StaticResource MarginSize.GroupBox.X}"
+               Top="{StaticResource MarginSize.GroupBox.Y}"
+               Right="{StaticResource MarginSize.GroupBox.X}"
+               Bottom="{StaticResource MarginSize.GroupBox.Y}" />
+    <Thickness x:Key="Margin.Label"
+               Left="{StaticResource MarginSize.Label.X}"
+               Top="{StaticResource MarginSize.Label.Y}"
+               Right="{StaticResource MarginSize.Label.X}"
+               Bottom="{StaticResource MarginSize.Label.Y}" />
+    <Thickness x:Key="Margin.RadioButton"
+               Left="{StaticResource MarginSize.RadioButton.X}"
+               Top="{StaticResource MarginSize.RadioButton.Y}"
+               Right="{StaticResource MarginSize.RadioButton.X}"
+               Bottom="{StaticResource MarginSize.RadioButton.Y}" />
+    <Thickness x:Key="Margin.Slider"
+               Left="{StaticResource MarginSize.Slider.X}"
+               Top="{StaticResource MarginSize.Slider.Y}"
+               Right="{StaticResource MarginSize.Slider.X}"
+               Bottom="{StaticResource MarginSize.Slider.Y}" />
+    <Thickness x:Key="Margin.TextBlock"
+               Left="{StaticResource MarginSize.TextBlock.X}"
+               Top="{StaticResource MarginSize.TextBlock.Y}"
+               Right="{StaticResource MarginSize.TextBlock.X}"
+               Bottom="{StaticResource MarginSize.TextBlock.Y}" />
+    <Thickness x:Key="Margin.TextBox"
+               Left="{StaticResource MarginSize.TextBox.X}"
+               Top="{StaticResource MarginSize.TextBox.Y}"
+               Right="{StaticResource MarginSize.TextBox.X}"
+               Bottom="{StaticResource MarginSize.TextBox.Y}" />
 
     <!-- Paddings -->
-    <Thickness x:Key="Padding.Default" Left="{StaticResource PaddingSize.Default}" Top="{StaticResource PaddingSize.Default}" Right="{StaticResource PaddingSize.Default}" Bottom="{StaticResource PaddingSize.Default}" />
+    <Thickness x:Key="Padding.Default"
+               Left="{StaticResource PaddingSize.Default}"
+               Top="{StaticResource PaddingSize.Default}"
+               Right="{StaticResource PaddingSize.Default}"
+               Bottom="{StaticResource PaddingSize.Default}" />
 
-    <Thickness x:Key="Padding.Label" Left="{StaticResource PaddingSize.Label.X}" Top="{StaticResource PaddingSize.Label.Y}" Right="{StaticResource PaddingSize.Label.X}" Bottom="{StaticResource PaddingSize.Label.Y}" />
-    <Thickness x:Key="Padding.TextBox" Left="{StaticResource PaddingSize.TextBox.X}" Top="{StaticResource PaddingSize.TextBox.Y}" Right="{StaticResource PaddingSize.TextBox.X}" Bottom="{StaticResource PaddingSize.TextBox.Y}" />
-    <Thickness x:Key="Padding.Combobox" Left="{StaticResource PaddingSize.Combobox.X}" Top="{StaticResource PaddingSize.Combobox.Y}" Right="{StaticResource PaddingSize.Combobox.X}" Bottom="{StaticResource PaddingSize.Combobox.Y}" />
+    <Thickness x:Key="Padding.Label"
+               Left="{StaticResource PaddingSize.Label.X}"
+               Top="{StaticResource PaddingSize.Label.Y}"
+               Right="{StaticResource PaddingSize.Label.X}"
+               Bottom="{StaticResource PaddingSize.Label.Y}" />
+    <Thickness x:Key="Padding.TextBox"
+               Left="{StaticResource PaddingSize.TextBox.X}"
+               Top="{StaticResource PaddingSize.TextBox.Y}"
+               Right="{StaticResource PaddingSize.TextBox.X}"
+               Bottom="{StaticResource PaddingSize.TextBox.Y}" />
+    <Thickness x:Key="Padding.Combobox"
+               Left="{StaticResource PaddingSize.Combobox.X}"
+               Top="{StaticResource PaddingSize.Combobox.Y}"
+               Right="{StaticResource PaddingSize.Combobox.X}"
+               Bottom="{StaticResource PaddingSize.Combobox.Y}" />
 
 </ResourceDictionary>


### PR DESCRIPTION
The TextBox had some sizing issues, but other controls as well when increasing the font size. The controls are now rendered correctly for different font sizes:

Font size 12:

![image](https://github.com/user-attachments/assets/aedfc8e0-0e61-474e-9e7f-6e91e37a3aad)

Font size 16:

![image](https://github.com/user-attachments/assets/59acf3f7-c16e-4c9f-8438-f1285c13c453)
