### PR TITLE
Support dynamic switching of fonts for ToolTip controls

### DIFF
--- a/src/Orc.Theming.Example/App.xaml.cs
+++ b/src/Orc.Theming.Example/App.xaml.cs
@@ -36,14 +36,15 @@ public partial class App
         var configurationService = ServiceLocator.Default.ResolveType<IConfigurationService>();
         await configurationService.LoadAsync();
 
-        var fontSize = configurationService.GetRoamingValue("FontSize", 12d);
-
-        var fontSizeService = ServiceLocator.Default.ResolveRequiredType<IFontSizeService>();
-        fontSizeService.SetFontSize(fontSize);
-
         Log.Info("Starting application");
         Log.Info("This log message should show up as debug");
 
         base.OnStartup(e);
+
+        // Note: run after window has been created
+        var fontSize = configurationService.GetRoamingValue("FontSize", 12d);
+
+        var fontSizeService = ServiceLocator.Default.ResolveRequiredType<IFontSizeService>();
+        fontSizeService.SetFontSize(fontSize);
     }
 }

--- a/src/Orc.Theming/Helpers/StyleHelper.cs
+++ b/src/Orc.Theming/Helpers/StyleHelper.cs
@@ -241,11 +241,11 @@ public static class StyleHelper
         }
 
         var keys = (from key in sourceResources.Keys as ICollection<object>
-            let stringKey = key as string
-            where stringKey != null &&
-                  (stringKey).StartsWith(defaultPrefix, StringComparison.Ordinal) &&
-                  (stringKey).EndsWith(DefaultKeyPostfix, StringComparison.Ordinal)
-            select stringKey).Distinct().ToList();
+                    let stringKey = key as string
+                    where stringKey != null &&
+                          stringKey.StartsWith(defaultPrefix, StringComparison.Ordinal) &&
+                          stringKey.EndsWith(DefaultKeyPostfix, StringComparison.Ordinal)
+                    select stringKey).Distinct().ToArray();
 
         foreach (var key in keys)
         {

--- a/src/Orc.Theming/Services/FontSizeService.cs
+++ b/src/Orc.Theming/Services/FontSizeService.cs
@@ -41,10 +41,17 @@ public class FontSizeService : IFontSizeService
 
         _fontSize = fontSize;
 
-        var mainWindow = Application.Current.MainWindow;
-        if (mainWindow is not null)
+        var application = Application.Current;
+        if (application is not null)
         {
-            TextBlock.SetFontSize(mainWindow, fontSize);
+            // Special case for tooltips: override font size as app resource
+            application.Resources["Orc.FontSizes.ToolTip"] = fontSize;
+            
+            var mainWindow = application.MainWindow;
+            if (mainWindow is not null)
+            {
+                TextBlock.SetFontSize(mainWindow, fontSize);
+            }
         }
 
         try
@@ -54,6 +61,7 @@ public class FontSizeService : IFontSizeService
             OverrideMetadataWithFontSize(TextBoxBase.FontSizeProperty, typeof(TextBoxBase), fontSize);
             OverrideMetadataWithFontSize(TextElement.FontSizeProperty, typeof(TextElement), fontSize);
             OverrideMetadataWithFontSize(ToolTip.FontSizeProperty, typeof(ToolTip), fontSize);
+
         }
         catch (Exception ex)
         {

--- a/src/Orc.Theming/Themes/Controls.implicit.wpf.tooltip.xaml
+++ b/src/Orc.Theming/Themes/Controls.implicit.wpf.tooltip.xaml
@@ -1,13 +1,20 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Orc.Theming">
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Orc.Theming;component/themes/Controls.implicit.wpf.control.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="Orc.Styles.ToolTip"
-           TargetType="ToolTip"
+           TargetType="{x:Type ToolTip}"
            BasedOn="{StaticResource Orc.Styles.Control}">
+        <!-- 
+            Note: tooltips are complex, and don't allow overriding metadata afterwards, so
+            it's important to use DynamicResource instead
+        -->
+        <Setter Property="FontSize"
+                Value="{DynamicResource Orc.FontSizes.ToolTip}" />
     </Style>
 
 </ResourceDictionary>

--- a/src/Orc.Theming/Themes/FontSizes.xaml
+++ b/src/Orc.Theming/Themes/FontSizes.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <sys:Double x:Key="Orc.FontSizes.ToolTip">12</sys:Double>
+
+</ResourceDictionary>

--- a/src/Orc.Theming/Themes/Generic.generated.xaml
+++ b/src/Orc.Theming/Themes/Generic.generated.xaml
@@ -1921,7 +1921,13 @@
   <Style x:Key="Orc.Styles.ToolBar" TargetType="{x:Type ToolBar}">
     <Setter Property="Background" Value="{DynamicResource Orc.Brushes.Control.Background}" />
   </Style>
-  <Style x:Key="Orc.Styles.ToolTip" TargetType="ToolTip" BasedOn="{StaticResource Orc.Styles.Control}" />
+  <Style x:Key="Orc.Styles.ToolTip" TargetType="{x:Type ToolTip}" BasedOn="{StaticResource Orc.Styles.Control}">
+    <!-- 
+            Note: tooltips are complex, and don't allow overriding metadata afterwards, so
+            it's important to use DynamicResource instead
+        -->
+    <Setter Property="FontSize" Value="{DynamicResource Orc.FontSizes.ToolTip}" />
+  </Style>
   <Style x:Key="Orc.Styles.TreeView" TargetType="TreeView" BasedOn="{StaticResource Orc.Styles.Control}">
     <Style.Resources />
     <Setter Property="OverridesDefaultStyle" Value="True" />


### PR DESCRIPTION
The solution uses DynamicResource since the metadata override trick does not seem to work for ToolTip.

The image below shows the tooltip respecting the current font size. It already supported dynamic light / dark mode.

![image](https://github.com/user-attachments/assets/54b5544c-6408-4b85-a5bd-7637b804a372)
