### PR TITLE
Prevents null reference exception

### DIFF
--- a/src/Orc.Theming/Behaviors/Square.cs
+++ b/src/Orc.Theming/Behaviors/Square.cs
@@ -54,6 +54,11 @@
 
         private void OnOrientationChanged()
         {
+            if (AssociatedObject is null)
+            {
+                return;
+            }
+
             UpdateSize();
         }
 


### PR DESCRIPTION
Adds a null check for the AssociatedObject in the OnOrientationChanged method.

This prevents a potential null reference exception when the orientation changes and the associated object is not yet initialized.

### Description of Change ###

<!-- Describe your changes here -->

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

<!-- List all API changes here (or just put None) -->
 
None

### Behavioral Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [ ] Changes adhere to coding standard
- [ ] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member